### PR TITLE
Module attacher

### DIFF
--- a/module.go
+++ b/module.go
@@ -13,6 +13,12 @@ type ModuleRequirements interface {
 	Requires() []string
 }
 
+// ModuleAttacher attaches it self to the parent router. It gives the parent router as argument before grouping into the Base() routes.
+// It useful for example to specify named middlewares that can be reused in the parent router.
+type ModuleAttacher interface {
+	Attach(*Router)
+}
+
 // Module register modules for the current router instance.
 func (r *Router) Module(modules ...Module) {
 	for _, m := range modules {
@@ -21,6 +27,10 @@ func (r *Router) Module(modules ...Module) {
 }
 
 func (r *Router) registerModule(m Module) {
+	if attacher, ok := m.(ModuleAttacher); ok {
+		attacher.Attach(r)
+	}
+
 	g := r.Group(m.Base())
 	if req, ok := m.(ModuleRequirements); ok {
 		for _, dep := range req.Requires() {


### PR DESCRIPTION
Allows a module to attach to the parent Router instance instead of the isolated router grouped from Base() method.

Uses cases:
* Register a named middlewares so that it can be available to parent Router instance and all of its children.
* Call available method relatively to the parent router

Alternative API:
* Restrict usage of Router
```go
type Definer interface{
	Define(name string, mws ...MiddlewareFunc)
}
type ModuleAttacher interface {
	Attach(Definer)
}
```