### PR TITLE
Consider removing color from the main package

### DIFF
--- a/router.go
+++ b/router.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/fatih/color"
 )
 
 // HTTP methods constants
@@ -479,8 +477,7 @@ func (r *Router) ServeFile(base, path string) {
 }
 
 var (
-	lionColor  = color.New(color.Italic, color.FgHiGreen).SprintFunc()
-	lionLogger = log.New(os.Stdout, lionColor("[lion]")+" ", log.Ldate|log.Ltime)
+	lionLogger = log.New(os.Stdout, "[lion] ", log.Ldate|log.Ltime)
 )
 
 // Run calls http.ListenAndServe for the current router.


### PR DESCRIPTION
I'd like to suggest removing the dependency on `github.com/fatih/color` from the main package.

Arguably having colored output is not super important, and by removing this dependency you're also cutting the number of additional dependencies needed to compile a simple program that just depends on `lion.Router`.

Using the following test program:

```go
package main

import (
	"net/http"

	"github.com/celrenheit/lion"
)

func main() {
	router := lion.New()

	http.ListenAndServe(":6060", router)
}
```

This is the dependencies vendored by using `govendor add +external` on the master branch:

    vendor/golang.org/x/sys
    vendor/github.com/celrenheit/lion
    vendor/github.com/fatih/color
    vendor/github.com/mattn/go-isatty
    vendor/github.com/mattn/go-colorable

This is the dependencies after applying this PR:

    vendor/github.com/celrenheit/lion
